### PR TITLE
Added link_directories() to wdk_add_driver() function

### DIFF
--- a/cmake/FindWdk.cmake
+++ b/cmake/FindWdk.cmake
@@ -69,10 +69,10 @@ set(WDK_COMPILE_FLAGS
 set(WDK_COMPILE_DEFINITIONS "WINNT=1")
 set(WDK_COMPILE_DEFINITIONS_DEBUG "MSC_NOOPT;DEPRECATE_DDK_FUNCTIONS=1;DBG=1")
 
-if(CMAKE_SIZEOF_VOID_P  EQUAL 4)
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
     list(APPEND WDK_COMPILE_DEFINITIONS "_X86_=1;i386=1;STD_CALL")
     set(WDK_PLATFORM "x86")
-elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
     list(APPEND WDK_COMPILE_DEFINITIONS "_WIN64;_AMD64_;AMD64")
     set(WDK_PLATFORM "x64")
 else()
@@ -94,7 +94,9 @@ string(CONCAT WDK_LINK_FLAGS
 
 function(wdk_add_driver _target)
     cmake_parse_arguments(WDK "" "KMDF;WINVER" "" ${ARGN})
-    
+
+    link_directories("${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}")
+
     add_executable(${_target} ${WDK_UNPARSED_ARGUMENTS})
 
     set_target_properties(${_target} PROPERTIES SUFFIX ".sys")
@@ -109,14 +111,9 @@ function(wdk_add_driver _target)
         "${WDK_ROOT}/Include/${WDK_VERSION}/km"
         )
 
-    target_link_libraries(${_target}
-        "${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/ntoskrnl.lib"
-        "${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/hal.lib"
-        "${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/BufferOverflowK.lib"
-        "${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/wmilib.lib"
-        )
+    target_link_libraries(${_target} ntoskrnl hal BufferOverflowK wmilib)
 
-    if(CMAKE_SIZEOF_VOID_P  EQUAL 4)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
         target_link_libraries(${_target} "${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/memcmp.lib")
     endif()
 
@@ -127,13 +124,13 @@ function(wdk_add_driver _target)
             "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfLdr.lib"
             )
 
-        if(CMAKE_SIZEOF_VOID_P  EQUAL 4)
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
             set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry@8")
         elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
             set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry")
         endif()
     else()
-        if(CMAKE_SIZEOF_VOID_P  EQUAL 4)
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
             set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry@8")
         elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
             set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry")


### PR DESCRIPTION
Hey,

Please review this PR.

The main purpose of it is to allow users to use `target_link_libraries()` the same way they would when linking any other library/executable in cmake. 

Meaning I added `${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}` to  wdk_add_driver()'s library search path so that users only have to do for example:
```
target_link_libraries(mydriver ndis setupapi)
```
instead of
```
target_link_libraries(mydriver
"${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/ndis.lib"
"${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/setupapi.lib")
```
in their` CMakeLists.txt`, which is something novice user would never figure out.

BTW if you think that adding `${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}` to `link_directories()` the way I did is going to pollute cmake's default library search path, then it isn't.
I don't have an exact explanation as to why, but it seems as if everything in `FindWdk.cmake` is processed in an separate sub-shell and discarded after success/failure.

If you like it then we could add a test case for this as well.