### PR TITLE
Don't keep processing if ntddk file isn't found

### DIFF
--- a/cmake/FindWdk.cmake
+++ b/cmake/FindWdk.cmake
@@ -35,14 +35,16 @@ file(GLOB WDK_NTDDK_FILES
     "C:/Program Files*/Windows Kits/10/Include/*/km/ntddk.h"
 )
 
-if(NOT WDK_NTDDK_FILES)
-    return()
+if(WDK_NTDDK_FILES)
+    list(GET WDK_NTDDK_FILES -1 WDK_LATEST_NTDDK_FILE)
 endif()
-
-list(GET WDK_NTDDK_FILES -1 WDK_LATEST_NTDDK_FILE)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(WDK REQUIRED_VARS WDK_LATEST_NTDDK_FILE)
+
+if (NOT WDK_LATEST_NTDDK_FILE)
+    return()
+endif()
 
 get_filename_component(WDK_ROOT ${WDK_LATEST_NTDDK_FILE} DIRECTORY)
 get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)

--- a/cmake/FindWdk.cmake
+++ b/cmake/FindWdk.cmake
@@ -35,133 +35,135 @@ file(GLOB WDK_NTDDK_FILES
     "C:/Program Files*/Windows Kits/10/Include/*/km/ntddk.h"
 )
 
-if(WDK_NTDDK_FILES)
-    list(GET WDK_NTDDK_FILES -1 WDK_LATEST_NTDDK_FILE)
+if(NOT WDK_NTDDK_FILES)
+    return()
+endif()
 
-    include(FindPackageHandleStandardArgs)
-    find_package_handle_standard_args(WDK REQUIRED_VARS WDK_LATEST_NTDDK_FILE)
+list(GET WDK_NTDDK_FILES -1 WDK_LATEST_NTDDK_FILE)
 
-    get_filename_component(WDK_ROOT ${WDK_LATEST_NTDDK_FILE} DIRECTORY)
-    get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
-    get_filename_component(WDK_VERSION ${WDK_ROOT} NAME)
-    get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
-    get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WDK REQUIRED_VARS WDK_LATEST_NTDDK_FILE)
 
-    message(STATUS "WDK_ROOT: " ${WDK_ROOT})
-    message(STATUS "WDK_VERSION: " ${WDK_VERSION})
+get_filename_component(WDK_ROOT ${WDK_LATEST_NTDDK_FILE} DIRECTORY)
+get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
+get_filename_component(WDK_VERSION ${WDK_ROOT} NAME)
+get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
+get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
 
-    set(WDK_WINVER "0x0601" CACHE STRING "Default WINVER for WDK targets")
+message(STATUS "WDK_ROOT: " ${WDK_ROOT})
+message(STATUS "WDK_VERSION: " ${WDK_VERSION})
 
-    set(WDK_ADDITIONAL_FLAGS_FILE "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/wdkflags.h")
-    file(WRITE ${WDK_ADDITIONAL_FLAGS_FILE} "#pragma runtime_checks(\"suc\", off)")
+set(WDK_WINVER "0x0601" CACHE STRING "Default WINVER for WDK targets")
 
-    set(WDK_COMPILE_FLAGS
-        "/Zp8" # set struct alignment
-        "/GF"  # enable string pooling
-        "/GR-" # disable RTTI
-        "/Gz" # __stdcall by default
-        "/kernel"  # create kernel mode binary
-        "/FIwarning.h" # disable warnings in WDK headers
-        "/FI${WDK_ADDITIONAL_FLAGS_FILE}" # include file to disable RTC
+set(WDK_ADDITIONAL_FLAGS_FILE "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/wdkflags.h")
+file(WRITE ${WDK_ADDITIONAL_FLAGS_FILE} "#pragma runtime_checks(\"suc\", off)")
+
+set(WDK_COMPILE_FLAGS
+    "/Zp8" # set struct alignment
+    "/GF"  # enable string pooling
+    "/GR-" # disable RTTI
+    "/Gz" # __stdcall by default
+    "/kernel"  # create kernel mode binary
+    "/FIwarning.h" # disable warnings in WDK headers
+    "/FI${WDK_ADDITIONAL_FLAGS_FILE}" # include file to disable RTC
+    )
+
+set(WDK_COMPILE_DEFINITIONS "WINNT=1")
+set(WDK_COMPILE_DEFINITIONS_DEBUG "MSC_NOOPT;DEPRECATE_DDK_FUNCTIONS=1;DBG=1")
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    list(APPEND WDK_COMPILE_DEFINITIONS "_X86_=1;i386=1;STD_CALL")
+    set(WDK_PLATFORM "x86")
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    list(APPEND WDK_COMPILE_DEFINITIONS "_WIN64;_AMD64_;AMD64")
+    set(WDK_PLATFORM "x64")
+else()
+    message(FATAL_ERROR "Unsupported architecture")
+endif()
+
+string(CONCAT WDK_LINK_FLAGS
+    "/MANIFEST:NO " #
+    "/DRIVER " #
+    "/OPT:REF " #
+    "/INCREMENTAL:NO " #
+    "/OPT:ICF " #
+    "/SUBSYSTEM:NATIVE " #
+    "/MERGE:_TEXT=.text;_PAGE=PAGE " #
+    "/NODEFAULTLIB " # do not link default CRT
+    "/SECTION:INIT,d " #
+    "/VERSION:10.0 " #
+    )
+
+# Generate imported targets for WDK lib files
+file(GLOB WDK_LIBRARIES "${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/*.lib")    
+foreach(LIBRARY IN LISTS WDK_LIBRARIES)
+    get_filename_component(LIBRARY_NAME ${LIBRARY} NAME_WE)
+    string(TOUPPER ${LIBRARY_NAME} LIBRARY_NAME)
+    add_library(WDK::${LIBRARY_NAME} INTERFACE IMPORTED)
+    set_property(TARGET WDK::${LIBRARY_NAME} PROPERTY INTERFACE_LINK_LIBRARIES  ${LIBRARY})
+endforeach(LIBRARY)
+unset(WDK_LIBRARIES)
+
+function(wdk_add_driver _target)
+    cmake_parse_arguments(WDK "" "KMDF;WINVER" "" ${ARGN})
+
+    add_executable(${_target} ${WDK_UNPARSED_ARGUMENTS})
+
+    set_target_properties(${_target} PROPERTIES SUFFIX ".sys")
+    set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
+    set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS
+        "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG}>;_WIN32_WINNT=${WDK_WINVER}"
+        )
+    set_target_properties(${_target} PROPERTIES LINK_FLAGS "${WDK_LINK_FLAGS}")
+
+    target_include_directories(${_target} SYSTEM PRIVATE
+        "${WDK_ROOT}/Include/${WDK_VERSION}/shared"
+        "${WDK_ROOT}/Include/${WDK_VERSION}/km"
         )
 
-    set(WDK_COMPILE_DEFINITIONS "WINNT=1")
-    set(WDK_COMPILE_DEFINITIONS_DEBUG "MSC_NOOPT;DEPRECATE_DDK_FUNCTIONS=1;DBG=1")
+    target_link_libraries(${_target} WDK::NTOSKRNL WDK::HAL WDK::BUFFEROVERFLOWK WDK::WMILIB)
 
     if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-        list(APPEND WDK_COMPILE_DEFINITIONS "_X86_=1;i386=1;STD_CALL")
-        set(WDK_PLATFORM "x86")
-    elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-        list(APPEND WDK_COMPILE_DEFINITIONS "_WIN64;_AMD64_;AMD64")
-        set(WDK_PLATFORM "x64")
-    else()
-        message(FATAL_ERROR "Unsupported architecture")
+        target_link_libraries(${_target} WDK::MEMCMP)
     endif()
 
-    string(CONCAT WDK_LINK_FLAGS
-        "/MANIFEST:NO " #
-        "/DRIVER " #
-        "/OPT:REF " #
-        "/INCREMENTAL:NO " #
-        "/OPT:ICF " #
-        "/SUBSYSTEM:NATIVE " #
-        "/MERGE:_TEXT=.text;_PAGE=PAGE " #
-        "/NODEFAULTLIB " # do not link default CRT
-        "/SECTION:INIT,d " #
-        "/VERSION:10.0 " #
-        )
-
-    # Generate imported targets for WDK lib files
-    file(GLOB WDK_LIBRARIES "${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/*.lib")    
-    foreach(LIBRARY IN LISTS WDK_LIBRARIES)
-        get_filename_component(LIBRARY_NAME ${LIBRARY} NAME_WE)
-        string(TOUPPER ${LIBRARY_NAME} LIBRARY_NAME)
-        add_library(WDK::${LIBRARY_NAME} INTERFACE IMPORTED)
-        set_property(TARGET WDK::${LIBRARY_NAME} PROPERTY INTERFACE_LINK_LIBRARIES  ${LIBRARY})
-    endforeach(LIBRARY)
-    unset(WDK_LIBRARIES)
-
-    function(wdk_add_driver _target)
-        cmake_parse_arguments(WDK "" "KMDF;WINVER" "" ${ARGN})
-
-        add_executable(${_target} ${WDK_UNPARSED_ARGUMENTS})
-
-        set_target_properties(${_target} PROPERTIES SUFFIX ".sys")
-        set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
-        set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS
-            "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG}>;_WIN32_WINNT=${WDK_WINVER}"
+    if(DEFINED WDK_KMDF)
+        target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
+        target_link_libraries(${_target}
+            "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfDriverEntry.lib"
+            "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfLdr.lib"
             )
-        set_target_properties(${_target} PROPERTIES LINK_FLAGS "${WDK_LINK_FLAGS}")
-
-        target_include_directories(${_target} SYSTEM PRIVATE
-            "${WDK_ROOT}/Include/${WDK_VERSION}/shared"
-            "${WDK_ROOT}/Include/${WDK_VERSION}/km"
-            )
-
-        target_link_libraries(${_target} WDK::NTOSKRNL WDK::HAL WDK::BUFFEROVERFLOWK WDK::WMILIB)
 
         if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-            target_link_libraries(${_target} WDK::MEMCMP)
+            set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry@8")
+        elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
+            set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry")
         endif()
-
-        if(DEFINED WDK_KMDF)
-            target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
-            target_link_libraries(${_target}
-                "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfDriverEntry.lib"
-                "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfLdr.lib"
-                )
-
-            if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry@8")
-            elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
-                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry")
-            endif()
-        else()
-            if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry@8")
-            elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
-                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry")
-            endif()
+    else()
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+            set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry@8")
+        elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
+            set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry")
         endif()
-    endfunction()
+    endif()
+endfunction()
 
-    function(wdk_add_library _target)
-        cmake_parse_arguments(WDK "" "KMDF;WINVER" "" ${ARGN})
+function(wdk_add_library _target)
+    cmake_parse_arguments(WDK "" "KMDF;WINVER" "" ${ARGN})
 
-        add_library(${_target} ${WDK_UNPARSED_ARGUMENTS})
+    add_library(${_target} ${WDK_UNPARSED_ARGUMENTS})
 
-        set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
-        set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS 
-            "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG};_WIN32_WINNT=${WDK_WINVER}>"
-            )
+    set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
+    set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS 
+        "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG};_WIN32_WINNT=${WDK_WINVER}>"
+        )
 
-        target_include_directories(${_target} SYSTEM PRIVATE
-            "${WDK_ROOT}/Include/${WDK_VERSION}/shared"
-            "${WDK_ROOT}/Include/${WDK_VERSION}/km"
-            )
+    target_include_directories(${_target} SYSTEM PRIVATE
+        "${WDK_ROOT}/Include/${WDK_VERSION}/shared"
+        "${WDK_ROOT}/Include/${WDK_VERSION}/km"
+        )
 
-        if(DEFINED WDK_KMDF)
-            target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
-        endif()
-    endfunction()
-endif()
+    if(DEFINED WDK_KMDF)
+        target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
+    endif()
+endfunction()

--- a/cmake/FindWdk.cmake
+++ b/cmake/FindWdk.cmake
@@ -37,131 +37,131 @@ file(GLOB WDK_NTDDK_FILES
 
 if(WDK_NTDDK_FILES)
     list(GET WDK_NTDDK_FILES -1 WDK_LATEST_NTDDK_FILE)
-endif()
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(WDK REQUIRED_VARS WDK_LATEST_NTDDK_FILE)
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(WDK REQUIRED_VARS WDK_LATEST_NTDDK_FILE)
 
-get_filename_component(WDK_ROOT ${WDK_LATEST_NTDDK_FILE} DIRECTORY)
-get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
-get_filename_component(WDK_VERSION ${WDK_ROOT} NAME)
-get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
-get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
+    get_filename_component(WDK_ROOT ${WDK_LATEST_NTDDK_FILE} DIRECTORY)
+    get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
+    get_filename_component(WDK_VERSION ${WDK_ROOT} NAME)
+    get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
+    get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
 
-message(STATUS "WDK_ROOT: " ${WDK_ROOT})
-message(STATUS "WDK_VERSION: " ${WDK_VERSION})
+    message(STATUS "WDK_ROOT: " ${WDK_ROOT})
+    message(STATUS "WDK_VERSION: " ${WDK_VERSION})
 
-set(WDK_WINVER "0x0601" CACHE STRING "Default WINVER for WDK targets")
+    set(WDK_WINVER "0x0601" CACHE STRING "Default WINVER for WDK targets")
 
-set(WDK_ADDITIONAL_FLAGS_FILE "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/wdkflags.h")
-file(WRITE ${WDK_ADDITIONAL_FLAGS_FILE} "#pragma runtime_checks(\"suc\", off)")
+    set(WDK_ADDITIONAL_FLAGS_FILE "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/wdkflags.h")
+    file(WRITE ${WDK_ADDITIONAL_FLAGS_FILE} "#pragma runtime_checks(\"suc\", off)")
 
-set(WDK_COMPILE_FLAGS
-    "/Zp8" # set struct alignment
-    "/GF"  # enable string pooling
-    "/GR-" # disable RTTI
-    "/Gz" # __stdcall by default
-    "/kernel"  # create kernel mode binary
-    "/FIwarning.h" # disable warnings in WDK headers
-    "/FI${WDK_ADDITIONAL_FLAGS_FILE}" # include file to disable RTC
-    )
-
-set(WDK_COMPILE_DEFINITIONS "WINNT=1")
-set(WDK_COMPILE_DEFINITIONS_DEBUG "MSC_NOOPT;DEPRECATE_DDK_FUNCTIONS=1;DBG=1")
-
-if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-    list(APPEND WDK_COMPILE_DEFINITIONS "_X86_=1;i386=1;STD_CALL")
-    set(WDK_PLATFORM "x86")
-elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    list(APPEND WDK_COMPILE_DEFINITIONS "_WIN64;_AMD64_;AMD64")
-    set(WDK_PLATFORM "x64")
-else()
-    message(FATAL_ERROR "Unsupported architecture")
-endif()
-
-string(CONCAT WDK_LINK_FLAGS
-    "/MANIFEST:NO " #
-    "/DRIVER " #
-    "/OPT:REF " #
-    "/INCREMENTAL:NO " #
-    "/OPT:ICF " #
-    "/SUBSYSTEM:NATIVE " #
-    "/MERGE:_TEXT=.text;_PAGE=PAGE " #
-    "/NODEFAULTLIB " # do not link default CRT
-    "/SECTION:INIT,d " #
-    "/VERSION:10.0 " #
-    )
-
-# Generate imported targets for WDK lib files
-file(GLOB WDK_LIBRARIES "${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/*.lib")    
-foreach(LIBRARY IN LISTS WDK_LIBRARIES)
-    get_filename_component(LIBRARY_NAME ${LIBRARY} NAME_WE)
-    string(TOUPPER ${LIBRARY_NAME} LIBRARY_NAME)
-    add_library(WDK::${LIBRARY_NAME} INTERFACE IMPORTED)
-    set_property(TARGET WDK::${LIBRARY_NAME} PROPERTY INTERFACE_LINK_LIBRARIES  ${LIBRARY})
-endforeach(LIBRARY)
-unset(WDK_LIBRARIES)
-
-function(wdk_add_driver _target)
-    cmake_parse_arguments(WDK "" "KMDF;WINVER" "" ${ARGN})
-
-    add_executable(${_target} ${WDK_UNPARSED_ARGUMENTS})
-
-    set_target_properties(${_target} PROPERTIES SUFFIX ".sys")
-    set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
-    set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS
-        "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG}>;_WIN32_WINNT=${WDK_WINVER}"
-        )
-    set_target_properties(${_target} PROPERTIES LINK_FLAGS "${WDK_LINK_FLAGS}")
-
-    target_include_directories(${_target} SYSTEM PRIVATE
-        "${WDK_ROOT}/Include/${WDK_VERSION}/shared"
-        "${WDK_ROOT}/Include/${WDK_VERSION}/km"
+    set(WDK_COMPILE_FLAGS
+        "/Zp8" # set struct alignment
+        "/GF"  # enable string pooling
+        "/GR-" # disable RTTI
+        "/Gz" # __stdcall by default
+        "/kernel"  # create kernel mode binary
+        "/FIwarning.h" # disable warnings in WDK headers
+        "/FI${WDK_ADDITIONAL_FLAGS_FILE}" # include file to disable RTC
         )
 
-    target_link_libraries(${_target} WDK::NTOSKRNL WDK::HAL WDK::BUFFEROVERFLOWK WDK::WMILIB)
+    set(WDK_COMPILE_DEFINITIONS "WINNT=1")
+    set(WDK_COMPILE_DEFINITIONS_DEBUG "MSC_NOOPT;DEPRECATE_DDK_FUNCTIONS=1;DBG=1")
 
     if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-        target_link_libraries(${_target} WDK::MEMCMP)
+        list(APPEND WDK_COMPILE_DEFINITIONS "_X86_=1;i386=1;STD_CALL")
+        set(WDK_PLATFORM "x86")
+    elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        list(APPEND WDK_COMPILE_DEFINITIONS "_WIN64;_AMD64_;AMD64")
+        set(WDK_PLATFORM "x64")
+    else()
+        message(FATAL_ERROR "Unsupported architecture")
     endif()
 
-    if(DEFINED WDK_KMDF)
-        target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
-        target_link_libraries(${_target}
-            "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfDriverEntry.lib"
-            "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfLdr.lib"
+    string(CONCAT WDK_LINK_FLAGS
+        "/MANIFEST:NO " #
+        "/DRIVER " #
+        "/OPT:REF " #
+        "/INCREMENTAL:NO " #
+        "/OPT:ICF " #
+        "/SUBSYSTEM:NATIVE " #
+        "/MERGE:_TEXT=.text;_PAGE=PAGE " #
+        "/NODEFAULTLIB " # do not link default CRT
+        "/SECTION:INIT,d " #
+        "/VERSION:10.0 " #
+        )
+
+    # Generate imported targets for WDK lib files
+    file(GLOB WDK_LIBRARIES "${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/*.lib")    
+    foreach(LIBRARY IN LISTS WDK_LIBRARIES)
+        get_filename_component(LIBRARY_NAME ${LIBRARY} NAME_WE)
+        string(TOUPPER ${LIBRARY_NAME} LIBRARY_NAME)
+        add_library(WDK::${LIBRARY_NAME} INTERFACE IMPORTED)
+        set_property(TARGET WDK::${LIBRARY_NAME} PROPERTY INTERFACE_LINK_LIBRARIES  ${LIBRARY})
+    endforeach(LIBRARY)
+    unset(WDK_LIBRARIES)
+
+    function(wdk_add_driver _target)
+        cmake_parse_arguments(WDK "" "KMDF;WINVER" "" ${ARGN})
+
+        add_executable(${_target} ${WDK_UNPARSED_ARGUMENTS})
+
+        set_target_properties(${_target} PROPERTIES SUFFIX ".sys")
+        set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
+        set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS
+            "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG}>;_WIN32_WINNT=${WDK_WINVER}"
+            )
+        set_target_properties(${_target} PROPERTIES LINK_FLAGS "${WDK_LINK_FLAGS}")
+
+        target_include_directories(${_target} SYSTEM PRIVATE
+            "${WDK_ROOT}/Include/${WDK_VERSION}/shared"
+            "${WDK_ROOT}/Include/${WDK_VERSION}/km"
             )
 
+        target_link_libraries(${_target} WDK::NTOSKRNL WDK::HAL WDK::BUFFEROVERFLOWK WDK::WMILIB)
+
         if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-            set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry@8")
-        elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
-            set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry")
+            target_link_libraries(${_target} WDK::MEMCMP)
         endif()
-    else()
-        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-            set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry@8")
-        elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
-            set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry")
+
+        if(DEFINED WDK_KMDF)
+            target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
+            target_link_libraries(${_target}
+                "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfDriverEntry.lib"
+                "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfLdr.lib"
+                )
+
+            if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry@8")
+            elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
+                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry")
+            endif()
+        else()
+            if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry@8")
+            elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
+                set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry")
+            endif()
         endif()
-    endif()
-endfunction()
+    endfunction()
 
-function(wdk_add_library _target)
-    cmake_parse_arguments(WDK "" "KMDF;WINVER" "" ${ARGN})
+    function(wdk_add_library _target)
+        cmake_parse_arguments(WDK "" "KMDF;WINVER" "" ${ARGN})
 
-    add_library(${_target} ${WDK_UNPARSED_ARGUMENTS})
+        add_library(${_target} ${WDK_UNPARSED_ARGUMENTS})
 
-    set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
-    set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS 
-        "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG};_WIN32_WINNT=${WDK_WINVER}>"
-        )
+        set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
+        set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS 
+            "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG};_WIN32_WINNT=${WDK_WINVER}>"
+            )
 
-    target_include_directories(${_target} SYSTEM PRIVATE
-        "${WDK_ROOT}/Include/${WDK_VERSION}/shared"
-        "${WDK_ROOT}/Include/${WDK_VERSION}/km"
-        )
+        target_include_directories(${_target} SYSTEM PRIVATE
+            "${WDK_ROOT}/Include/${WDK_VERSION}/shared"
+            "${WDK_ROOT}/Include/${WDK_VERSION}/km"
+            )
 
-    if(DEFINED WDK_KMDF)
-        target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
-    endif()
-endfunction()
+        if(DEFINED WDK_KMDF)
+            target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
+        endif()
+    endfunction()
+endif()


### PR DESCRIPTION
If WDK is not present/can't be found, the build aborts with:
```plain
CMake Error at C:/Program Files/CMake/share/cmake-3.9/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find WDK (missing: WDK_LATEST_NTDDK_FILE)
```
without ever even reaching my test for `WDK_FOUND`. This change corrects that problem by stopping processing if no NTDDK files are found.