### PR TITLE
detect and use Enterprise WDK environment

### DIFF
--- a/cmake/FindWdk.cmake
+++ b/cmake/FindWdk.cmake
@@ -31,9 +31,15 @@
 #   target_link_libraries(KmdfCppDriver KmdfCppLib)
 #
 
-file(GLOB WDK_NTDDK_FILES
-    "C:/Program Files*/Windows Kits/10/Include/*/km/ntddk.h"
-)
+if ( DEFINED ENV{WindowsSdkDir} )
+    file(GLOB WDK_NTDDK_FILES
+        "$ENV{WindowsSdkDir}/Include/*/km/ntddk.h"
+    )
+else()
+    file(GLOB WDK_NTDDK_FILES
+        "C:/Program Files*/Windows Kits/10/Include/*/km/ntddk.h"
+    )
+endif()
 
 if(WDK_NTDDK_FILES)
     list(GET WDK_NTDDK_FILES -1 WDK_LATEST_NTDDK_FILE)


### PR DESCRIPTION
This PR enables detection of a Enterprise WDK environment (https://docs.microsoft.com/en-us/windows-hardware/drivers/develop/using-the-enterprise-wdk). If the EWDK environment is found, it is used for driver builds.