### PR TITLE
Demonstrate and fix failure to use CRT functions from a wdk_add_library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /build32
 /build64
+/samples/build

--- a/cmake/FindWdk.cmake
+++ b/cmake/FindWdk.cmake
@@ -170,6 +170,7 @@ function(wdk_add_library _target)
     target_include_directories(${_target} SYSTEM PRIVATE
         "${WDK_ROOT}/Include/${WDK_VERSION}/shared"
         "${WDK_ROOT}/Include/${WDK_VERSION}/km"
+        "${WDK_ROOT}/Include/${WDK_VERSION}/km/crt"
         )
 
     if(DEFINED WDK_KMDF)

--- a/samples/KmdfCppDriver/Main.cpp
+++ b/samples/KmdfCppDriver/Main.cpp
@@ -2,10 +2,15 @@
 #include <wdf.h>
 #include "KmdfCppLib.h"
 
+#include <stdio.h>
+
 EVT_WDF_DRIVER_UNLOAD evtDriverUnload;
 VOID evtDriverUnload(_In_ WDFDRIVER /*driver*/)
 {
-    DbgPrint("Driver unloaded\n");
+    char msg[17];
+    _snprintf_s(msg, 17, "%s", "Driver unloaded\n");
+
+    DbgPrint(msg);
 }
 
 extern "C" DRIVER_INITIALIZE DriverEntry;

--- a/samples/KmdfCppLib/KmdfCppLib.cpp
+++ b/samples/KmdfCppLib/KmdfCppLib.cpp
@@ -1,8 +1,13 @@
 #include "KmdfCppLib.h"
 
+#include <stdio.h>
+
 WDFSTRING getAnswer()
 {
-    static const UNICODE_STRING str = RTL_CONSTANT_STRING(L"42");
+    static wchar_t answer[3];
+    _snwprintf_s(answer, 3, L"%s", L"42");
+
+    static const UNICODE_STRING str = RTL_CONSTANT_STRING(answer);
 
     WDFSTRING wdfstr = nullptr;
     NTSTATUS status = WdfStringCreate(&str, WDF_NO_OBJECT_ATTRIBUTES, &wdfstr);


### PR DESCRIPTION
Demonstrate and fix failure to use CRT functions from a wdk_add_library

Modify the tests to inject the failure
- They fail to build for a library, at link time.
- But the main driver project doesn't participate in the failure.

Also add samples/build to .gitignore
- It includes /build, but there's no CMakeLists.txt at the root, so the build folder ends up naturally under samples (using VSCode)

Fixes #16 