### PR TITLE
make NTDDI_VERSION configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ FindWDK will search for the installed Windows Development Kit (WDK) and expose c
 - `WDK_ROOT` -- where WDK is installed
 - `WDK_VERSION` -- the version of the selected WDK
 - `WDK_WINVER` -- the WINVER used for kernel drivers and libraries (default value is `0x0601` and can be changed per target or globally)
+- `WDK_NTDDI_VERSION` -- the NTDDI_VERSION used for kernel drivers and libraries, if not set, the value will be automatically calculated by WINVER
 
 ## Kernel driver
 The following command adds a kernel driver target called `<name>` to be built from the source files listed in the command invocation:
@@ -40,6 +41,7 @@ wdk_add_driver(<name>
     [EXCLUDE_FROM_ALL]
     [KMDF <kmdf_version>]
     [WINVER <winver_version>]
+    [NTDDI_VERSION <ntddi_version>]
     source1 [source2 ...]
     )
 ```
@@ -48,6 +50,7 @@ Options:
 - `EXCLUDE_FROM_ALL` -- exclude from the default build target
 - `KMDF <kmdf_version>` -- use KMDF and set KMDF version
 - `WINVER <winver_version>` -- use specific WINVER version
+- `NTDDI_VERSION <ntddi_version>` -- use specific NTDDI_VERSION
 
 Example:
 
@@ -67,6 +70,7 @@ wdk_add_library(<name> [STATIC | SHARED]
     [EXCLUDE_FROM_ALL]
     [KMDF <kmdf_version>]
     [WINVER <winver_version>]
+    [NTDDI_VERSION <ntddi_version>]
     source1 [source2 ...]
     )
 ```
@@ -75,6 +79,7 @@ Options:
 - `EXCLUDE_FROM_ALL` -- exclude from the default build target
 - `KMDF <kmdf_version>` -- use KMDF and set KMDF version
 - `WINVER <winver_version>` -- use specific WINVER version
+- `NTDDI_VERSION <ntddi_version>` -- use specific NTDDI_VERSION
 - `STATIC or SHARED` -- specify the type of library to be created
 
 Example:

--- a/cmake/FindWdk.cmake
+++ b/cmake/FindWdk.cmake
@@ -14,6 +14,9 @@
 # - `WDK_VERSION` -- the version of the selected WDK
 # - `WDK_WINVER` -- the WINVER used for kernel drivers and libraries
 #        (default value is `0x0601` and can be changed per target or globally)
+# - `WDK_NTDDI_VERSION` -- the NTDDI_VERSION used for kernel drivers and libraries,
+#                          if not set, the value will be automatically calculated by WINVER
+#        (default value is left blank and can be changed per target or globally)
 #
 # Example usage:
 #
@@ -162,7 +165,7 @@ function(wdk_add_driver _target)
 endfunction()
 
 function(wdk_add_library _target)
-    cmake_parse_arguments(WDK "" "KMDF;WINVER" "" ${ARGN})
+    cmake_parse_arguments(WDK "" "KMDF;WINVER;NTDDI_VERSION" "" ${ARGN})
 
     add_library(${_target} ${WDK_UNPARSED_ARGUMENTS})
 
@@ -170,6 +173,9 @@ function(wdk_add_library _target)
     set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS
         "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG};>_WIN32_WINNT=${WDK_WINVER}"
         )
+    if(WDK_NTDDI_VERSION)
+        target_compile_definitions(${_target} PRIVATE NTDDI_VERSION=${WDK_NTDDI_VERSION})
+    endif()
 
     target_include_directories(${_target} SYSTEM PRIVATE
         "${WDK_ROOT}/Include/${WDK_VERSION}/shared"

--- a/cmake/FindWdk.cmake
+++ b/cmake/FindWdk.cmake
@@ -5,14 +5,14 @@
 # FindWDK
 # ----------
 #
-# This module searches for the installed Windows Development Kit (WDK) and 
+# This module searches for the installed Windows Development Kit (WDK) and
 # exposes commands for creating kernel drivers and kernel libraries.
 #
 # Output variables:
 # - `WDK_FOUND` -- if false, do not try to use WDK
 # - `WDK_ROOT` -- where WDK is installed
 # - `WDK_VERSION` -- the version of the selected WDK
-# - `WDK_WINVER` -- the WINVER used for kernel drivers and libraries 
+# - `WDK_WINVER` -- the WINVER used for kernel drivers and libraries
 #        (default value is `0x0601` and can be changed per target or globally)
 #
 # Example usage:
@@ -20,7 +20,7 @@
 #   find_package(WDK REQUIRED)
 #
 #   wdk_add_library(KmdfCppLib STATIC KMDF 1.15
-#       KmdfCppLib.h 
+#       KmdfCppLib.h
 #       KmdfCppLib.cpp
 #       )
 #   target_include_directories(KmdfCppLib INTERFACE .)
@@ -62,6 +62,7 @@ message(STATUS "WDK_ROOT: " ${WDK_ROOT})
 message(STATUS "WDK_VERSION: " ${WDK_VERSION})
 
 set(WDK_WINVER "0x0601" CACHE STRING "Default WINVER for WDK targets")
+set(WDK_NTDDI_VERSION "" CACHE STRING "Specified NTDDI_VERSION for WDK targets if needed")
 
 set(WDK_ADDITIONAL_FLAGS_FILE "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/wdkflags.h")
 file(WRITE ${WDK_ADDITIONAL_FLAGS_FILE} "#pragma runtime_checks(\"suc\", off)")
@@ -103,7 +104,7 @@ string(CONCAT WDK_LINK_FLAGS
     )
 
 # Generate imported targets for WDK lib files
-file(GLOB WDK_LIBRARIES "${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/*.lib")    
+file(GLOB WDK_LIBRARIES "${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/*.lib")
 foreach(LIBRARY IN LISTS WDK_LIBRARIES)
     get_filename_component(LIBRARY_NAME ${LIBRARY} NAME_WE)
     string(TOUPPER ${LIBRARY_NAME} LIBRARY_NAME)
@@ -113,7 +114,7 @@ endforeach(LIBRARY)
 unset(WDK_LIBRARIES)
 
 function(wdk_add_driver _target)
-    cmake_parse_arguments(WDK "" "KMDF;WINVER" "" ${ARGN})
+    cmake_parse_arguments(WDK "" "KMDF;WINVER;NTDDI_VERSION" "" ${ARGN})
 
     add_executable(${_target} ${WDK_UNPARSED_ARGUMENTS})
 
@@ -123,6 +124,9 @@ function(wdk_add_driver _target)
         "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG}>;_WIN32_WINNT=${WDK_WINVER}"
         )
     set_target_properties(${_target} PROPERTIES LINK_FLAGS "${WDK_LINK_FLAGS}")
+    if(WDK_NTDDI_VERSION)
+        target_compile_definitions(${_target} PRIVATE NTDDI_VERSION=${WDK_NTDDI_VERSION})
+    endif()
 
     target_include_directories(${_target} SYSTEM PRIVATE
         "${WDK_ROOT}/Include/${WDK_VERSION}/shared"
@@ -163,7 +167,7 @@ function(wdk_add_library _target)
     add_library(${_target} ${WDK_UNPARSED_ARGUMENTS})
 
     set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
-    set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS 
+    set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS
         "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG};>_WIN32_WINNT=${WDK_WINVER}"
         )
 


### PR DESCRIPTION
In general, NTDDI_VERSION will be set according to the value of _WIN32_WINNT in sdkddkver.h, but the latter can not distinguish minor OS versions like 19H1 and 21H1. This PR exposes another cache entry to access this macro definition.