### PR TITLE
add installation for uniform usage for FindWDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/build
+build*
 /build32
 /build64
 /samples/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.23.2)
+project(FindWDK)
+set(TARGET_NAME ${PROJECT_NAME})
+
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+
+set(INCLUDE_INSTALL_DIR include/ )
+
+install(FILES cmake/${PROJECT_NAME}.cmake
+  DESTINATION include
+  COMPONENT headers
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_PREFIX}"
+    PATH_VARS INCLUDE_INSTALL_DIR
+)
+
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}"
+)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 CMake module for building drivers with Windows Development Kit (WDK) [![Build status](https://ci.appveyor.com/api/projects/status/o7cyircahkb6nv07/branch/master?svg=true)](https://ci.appveyor.com/project/SergiusTheBest/findwdk/branch/master) [![CI](https://github.com/SergiusTheBest/FindWDK/actions/workflows/ci.yml/badge.svg)](https://github.com/SergiusTheBest/FindWDK/actions/workflows/ci.yml)
 
 - [Introduction](#introduction)
+  - [Build](#build)
+  - [Install](#install)
 - [Usage](#usage)
+  - [Optional Usage](#optional-usage)
+  - [FindWDK Output Variables](#findwdk-output-variables)
   - [Kernel driver](#kernel-driver)
   - [Kernel library](#kernel-library)
   - [Linking to WDK libraries](#linking-to-wdk-libraries)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # FindWDK
+
 CMake module for building drivers with Windows Development Kit (WDK) [![Build status](https://ci.appveyor.com/api/projects/status/o7cyircahkb6nv07/branch/master?svg=true)](https://ci.appveyor.com/project/SergiusTheBest/findwdk/branch/master) [![CI](https://github.com/SergiusTheBest/FindWDK/actions/workflows/ci.yml/badge.svg)](https://github.com/SergiusTheBest/FindWDK/actions/workflows/ci.yml)
 
 - [Introduction](#introduction)
@@ -11,22 +12,61 @@ CMake module for building drivers with Windows Development Kit (WDK) [![Build st
 - [Version history](#version-history)
 
 # Introduction
+
 FindWDK makes it possible to build kernel drivers and kernel libraries with Windows Development Kit (WDK) and CMake.
 
 Requirements:
+
 - WDK 8.0 and higher
 - Visual Studio 2015 and higher
 - CMake 3.0 and higher
 
+## Build
+
+Though no source is in this installation, a simple CMakeLists.txt was included to allow installation of packages. Simply "build and install" like you would any other package.
+
+```powershell
+mkdir build-out
+cd build-out
+cmake ..
+MSBuild.exe FindWDK.sln
+```
+
+Didn't really need the build step, but thought it would be uniform.
+
+## Install
+
+Then from a administrator command prompt:
+
+```powershell
+MSBuild.exe INSTALL.vcxproj
+```
+
+You can find the files in `C:/Program Files (x86)/FindWDK`.
+
 # Usage
-Add FindWDK to the module search path and call `find_package`:
+
+If you installed the package in the above step, you just need to call `find_package` on it.
 
 ```cmake
-list(APPEND CMAKE_MODULE_PATH "<path_to_FindWDK>")
+find_package(FindWDK)
+```
+
+Then add the `INCLUDE_DIR` path to your `CMAKE_MODULE_PATH`:
+
+```cmake
+list(APPEND CMAKE_MODULE_PATH ${FindWDK_INCLUDE_DIR})
 find_package(WDK REQUIRED)
 ```
 
+## Optional Usage
+
+You may add `FindWDK` to the module search path and call `find_package`. if you did not perform the build and install. You can then replace `${FindWDK_INCLUDE_DIR}` with  `"<path_to_FindWDK>"` being the local path of FindWDK on your system.
+
+## FindWDK Output Variables
+
 FindWDK will search for the latest installed Windows Development Kit (WDK) and expose commands for creating kernel drivers and kernel libraries. Also the following variables will be defined:
+
 - `WDK_FOUND` -- if false, do not try to use WDK
 - `WDK_ROOT` -- where WDK is installed
 - `WDK_VERSION` -- the version of the selected WDK
@@ -36,6 +76,7 @@ FindWDK will search for the latest installed Windows Development Kit (WDK) and e
 `WDKContentRoot` environment variable overrides the default WDK search path.
 
 ## Kernel driver
+
 The following command adds a kernel driver target called `<name>` to be built from the source files listed in the command invocation:
 
 ```cmake
@@ -49,6 +90,7 @@ wdk_add_driver(<name>
 ```
 
 Options:
+
 - `EXCLUDE_FROM_ALL` -- exclude from the default build target
 - `KMDF <kmdf_version>` -- use KMDF and set KMDF version
 - `WINVER <winver_version>` -- use specific WINVER version
@@ -65,6 +107,7 @@ wdk_add_driver(KmdfCppDriver
 ```
 
 ## Kernel library
+
 The following command adds a kernel library target called `<name>` to be built from the source files listed in the command invocation:
 
 ```cmake
@@ -78,6 +121,7 @@ wdk_add_library(<name> [STATIC | SHARED]
 ```
 
 Options:
+
 - `EXCLUDE_FROM_ALL` -- exclude from the default build target
 - `KMDF <kmdf_version>` -- use KMDF and set KMDF version
 - `WINVER <winver_version>` -- use specific WINVER version
@@ -96,6 +140,7 @@ wdk_add_library(KmdfCppLib STATIC
 ```
 
 ## Linking to WDK libraries
+
 FindWDK creates imported targets for all WDK libraries. The naming pattern is `WDK::<UPPERCASED_LIBNAME>`. Linking a minifilter driver to `FltMgr.lib` is shown below:
 
 ```cmake
@@ -103,9 +148,11 @@ target_link_libraries(MinifilterCppDriver WDK::FLTMGR)
 ```
 
 # Samples
+
 Take a look at the [samples](samples) folder to see how WMD and KMDF drivers and libraries are built.
 
 # License
+
 FindWDK is licensed under the OSI-approved 3-clause BSD license. You can freely use it in your commercial or opensource software.
 
 # Version history
@@ -113,9 +160,11 @@ FindWDK is licensed under the OSI-approved 3-clause BSD license. You can freely 
 ## Version 1.0.2 (TBD)
 
 ## Version 1.0.1 (13 Mar 2018)
+
 - New: Add ability to link to WDK libraries
 - New: Add MinifilterCppDriver sample
 - Fix: W4 warnings in C version of the driver, add missing /W4 /WX for C compiler
 
 ## Version 1.0.0 (03 Feb 2018)
+
 - Initial public release

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+set_and_check("@TARGET_NAME@_INCLUDE_DIR" "@PACKAGE_INCLUDE_INSTALL_DIR@")
+
+check_required_components("@TARGET_NAME@")


### PR DESCRIPTION
added CmakeLists.txt so that usage of FindWDK can be uniform for all users, allowing no localpaths and just the Program Files (x86) path.

Users will now just need the triple
```cmake
find_package(FindWDK)

list(APPEND CMAKE_MODULE_PATH ${FindWDK_INCLUDE_DIR})
find_package(WDK REQUIRED)
``` 
In any cmake file with a driver.